### PR TITLE
Fix escaping of escaped xpaths

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -366,7 +366,8 @@ JS;
      */
     public function getValue($xpath)
     {
-        $xpath = $this->prepareXPath($xpath);
+        $xpathEscaped = $this->prepareXPath($xpath);
+        
         $tag   = $this->getTagName($xpath);
         $type  = $this->getAttribute($xpath, 'type');
         $value = null;
@@ -398,7 +399,7 @@ JS;
                 return $this->evaluateScript($function);
             }
         } elseif ('checkbox' === $type) {
-            return $this->client->findByXPath($xpath)->isChecked();
+            return $this->client->findByXPath($xpathEscaped)->isChecked();
         } elseif ('select' === $tag && 'multiple' === $this->getAttribute($xpath, 'multiple')) {
             $name = $this->getAttribute($xpath, 'name');
 
@@ -429,7 +430,7 @@ JS;
             }
         }
 
-        return $this->client->findByXPath($xpath)->getValue();
+        return $this->client->findByXPath($xpathEscaped)->getValue();
     }
 
     /**


### PR DESCRIPTION
The getValue() function calls several internal methods like getAttribute and the like. These expect an UNESCAPED xpath (as they escape internally). the first thing happening in getValue() however is that it escapes the xpath

When doing stuff like:

$this->getMink()->getSession()->getPage()->find('xpath', '//input[@id="test"')->getValue()

Sahi will die with a javascript error :S
