### PR TITLE
Allow to specify alternative (not always 'localhost') Sahi server url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php: [5.3, 5.4, 5.5]
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost
   - export WEB_FIXTURES_BROWSER=firefox
+  - export DRIVER_HOST=localhost
 
   - sh -e /etc/init.d/xvfb start
   - export DISPLAY=:99.0

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <php>
         <!--server name="WEB_FIXTURES_HOST" value="http://test.mink.dev" /-->
         <!--server name="WEB_FIXTURES_BROWSER" value="firefox" /-->
+        <!--server name="DRIVER_HOST" value="localhost" /-->
     </php>
 
     <filter>

--- a/tests/Behat/Mink/Driver/SahiDriverTest.php
+++ b/tests/Behat/Mink/Driver/SahiDriverTest.php
@@ -6,6 +6,8 @@ use Behat\Mink\Mink,
     Behat\Mink\Session;
 
 use Behat\Mink\Driver\SahiDriver;
+use Behat\SahiClient\Client;
+use Behat\SahiClient\Connection;
 
 /**
  * @group sahidriver
@@ -14,7 +16,9 @@ class SahiDriverTest extends JavascriptDriverTest
 {
     protected static function getDriver()
     {
-        return new SahiDriver($_SERVER['WEB_FIXTURES_BROWSER']);
+        $connection = new Connection(null, $_SERVER['DRIVER_HOST'], 9999);
+
+        return new SahiDriver($_SERVER['WEB_FIXTURES_BROWSER'], new Client($connection));
     }
 
     /**


### PR DESCRIPTION
Allows to use any Sahi server for testing SahiDriver itself, not only `localhost`, as was before.

Also setting for server path mapping (see https://github.com/Behat/Mink/pull/342 pull request).

Similar functionality for Selenium2Driver: https://github.com/Behat/MinkSelenium2Driver/pull/56
