### PR TITLE
Value for missing cookie was reported as empty string instead of null

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -176,7 +176,9 @@ class SahiDriver extends CoreDriver
     public function getCookie($name)
     {
         try {
-            return urldecode($this->evaluateScript(sprintf('_sahi._cookie("%s")', $name)));
+            $cookieValue = $this->evaluateScript(sprintf('_sahi._cookie("%s")', $name));
+
+            return null === $cookieValue ? null : urldecode($cookieValue);
         } catch (ConnectionException $e) {}
     }
 


### PR DESCRIPTION
Value for missing cookie was reported as empty string instead of null because of `urldecode` function was returning empty string when `null` was given as input.

The `testCookie` was failing for me locally because of this.
