### PR TITLE
Fixes double xpath escaping in `selectRadioOption`

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -659,7 +659,7 @@ JS;
      */
     private function selectRadioOption($xpath, $value)
     {
-        $name = $this->getAttribute($this->prepareXPath($xpath), 'name');
+        $name = $this->getAttribute($xpath, 'name');
 
         if (null !== $name) {
             $function = <<<JS

--- a/tests/Behat/Mink/Driver/SahiDriverTest.php
+++ b/tests/Behat/Mink/Driver/SahiDriverTest.php
@@ -51,4 +51,20 @@ class SahiDriverTest extends JavascriptDriverTest
     {
         $this->markTestSkipped('Sahi doesn\'t support window switching');
     }
+
+    /**
+     * @group test-only
+     */
+    public function testIssue32()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/advanced_form.php'));
+        $page = $session->getPage();
+
+        $sex = $page->find('xpath', '//*[@name = "sex"]' . "\n|\n" . '//*[@id = "sex"]');
+        $this->assertNotNull($sex, 'xpath with line ending works');
+
+        $sex->setValue('m');
+        $this->assertEquals('m', $sex->getValue(), 'no double xpath escaping during radio button value change');
+    }
 }


### PR DESCRIPTION
Added tests won't pass because xpath being incorrectly escaped (see #31). Because of this we need to:
1. merge this PR
2. rebase changes from #31 onto it
3. run tests for #31, since they will pass

Fixes #32
