### PR TITLE
Added a catching of the SahiClient exception to wrap it in DriverException

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -205,7 +205,7 @@ JS;
             $cookieValue = $this->evaluateScript(sprintf('_sahi._cookie("%s")', $name));
 
             return null === $cookieValue ? null : urldecode($cookieValue);
-        } catch (ConnectionException $e) {
+        } catch (DriverException $e) {
             // ignore error
         }
 


### PR DESCRIPTION
Refs https://github.com/Behat/Mink/issues/473

The error message are not detailed because Sahi does not let SahiClient handle element not founds in a nice way (`findByXPath` only gives you an accessor for the element, it does not perform any JS action to check whether this XPath matches)
