### PR TITLE
Some example ENV vars in "phpunit.xml.dist" were missing

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,10 @@
         <!--server name="WEB_FIXTURES_HOST" value="http://test.mink.dev" /-->
         <!--server name="WEB_FIXTURES_BROWSER" value="firefox" /-->
         <!--server name="DRIVER_HOST" value="localhost" /-->
+
+        <!-- where DocumentRoot of 'Test Machine' is mounted to on 'Driver Machine' (only if these are 2 different machines) -->
+        <!--server name="DRIVER_MACHINE_BASE_PATH" value="" /-->
+        <!--server name="TEST_MACHINE_BASE_PATH" value="" /-->
     </php>
 
     <filter>


### PR DESCRIPTION
The ENV variables in the `phpunit.xml.dist`, that explained how to setup test server on one machine and Sahi on another were missing.
