### PR TITLE
Fix the handling of cookies with semicolon

### DIFF
--- a/src/SahiDriver.php
+++ b/src/SahiDriver.php
@@ -152,7 +152,11 @@ JS;
         if (null === $value) {
             $this->deleteCookie($name);
         } else {
-            $this->executeScript(sprintf('_sahi._createCookie(%s, %s)', json_encode($name), json_encode($value)));
+            $this->executeScript(sprintf(
+                '_sahi._createCookie(%s, %s)',
+                json_encode($name),
+                json_encode(urlencode($value))
+            ));
         }
     }
 


### PR DESCRIPTION
Turns out half of the fix was already there (the cookie value was urldecoded), but no urlecoding happened at all.
